### PR TITLE
Now also works on OS X, FreeBSD and with current OpenSSL website

### DIFF
--- a/lib/build
+++ b/lib/build
@@ -5,12 +5,22 @@
 
 source lib/common.inc
 
+if command -v nproc >/dev/null 2>&1 ; then
+	NUMCPUS=$(nproc)
+elif command -v gnproc >/dev/null 2>&1 ; then
+	NUMCPUS=$(gnproc)
+elif command -v sysctl >/dev/null 2>&1 ; then
+	NUMCPUS=$(sysctl hw.ncpu | awk '{print $2}')
+else
+	NUMCPUS=4 ; # Hopefully sane default in 2014
+fi
+
 function buildjob() {
 	local ret=0
 	gcc -v
 	[ -f Configure ] 	&& ./Configure
 	./config		|| return
-	time make -j$(nproc)	|| ret=$?
+	time make -j$NUMCPUS	|| ret=$?
 	[ -f util/selftest.pl ] && perl util/selftest.pl
 	return ${ret}
 	# some OpenSSL versions (such as 0.9.8 and 1.0.1) will produce
@@ -22,7 +32,8 @@ function buildjob() {
 
 [ -d work ] || fail "no 'work/' directory exists"
 
-timestamp=$(date --rfc-3339=seconds | sed 's/ /_/')
+# timestamp=$(date --rfc-3339=seconds | sed 's/ /_/')
+timestamp=$(date -u +"%Y-%m-%d_%H-%M-%S")
 echo "${banner} full log in work/OPENSSLDIR/buildlog-${timestamp}.log"
 for dir in work/*/; do
 	echo -ne "\tbuilding in ${dir} "
@@ -35,4 +46,3 @@ for dir in work/*/; do
 	fi
 	cd - &>/dev/null
 done
-

--- a/lib/build
+++ b/lib/build
@@ -10,7 +10,7 @@ if command -v nproc >/dev/null 2>&1 ; then
 elif command -v gnproc >/dev/null 2>&1 ; then
 	NUMCPUS=$(gnproc)
 elif command -v sysctl >/dev/null 2>&1 ; then
-	NUMCPUS=$(sysctl hw.ncpu | awk '{print $2}')
+	NUMCPUS=$(sysctl -n hw.ncpu)
 else
 	NUMCPUS=4 ; # Hopefully sane default in 2014
 fi

--- a/lib/common.inc
+++ b/lib/common.inc
@@ -23,17 +23,14 @@ function bold() {
 
 # Autodetect MD5 checker, md5sum, md5, openssl dgst -md5
 if command -v md5sum >/dev/null 2>&1 ; then # md5sum is used on Linux
-        echo "Using $(command -v md5sum) to verify checksums" >&2
         function md5check() {
                 echo $(md5sum ${1} | awk '{ print $1 }')
         }
 elif command -v md5 >/dev/null 2>&1 ; then # md5 is used on OS X
-        echo "Using $(command -v md5) to verify checksums" >&2
         function md5check() {
                 echo $(md5 ${1} | awk '{ print $4 }')
         }
 elif command -v openssl >/dev/null 2>&1 ; then # openssl is used if none of the above are found.
-        echo "Using $(command -v openssl) dgst -md5 to verify checksums" >&2
         function md5check() {
                 echo $(openssl dgst -md5 ${1} | awk '{ print $2 }')
         }

--- a/lib/common.inc
+++ b/lib/common.inc
@@ -19,5 +19,26 @@ function fail() {
 function bold() {
 	local text=${1}
 	echo "$(tput bold)${text}$(tput sgr0)"
-}
+};
+
+# Autodetect MD5 checker, md5sum, md5, openssl dgst -md5
+if command -v md5sum >/dev/null 2>&1 ; then # md5sum is used on Linux
+        echo "Using $(command -v md5sum) to verify checksums" >&2
+        function md5check() {
+                echo $(md5sum ${1} | awk '{ print $1 }')
+        }
+elif command -v md5 >/dev/null 2>&1 ; then # md5 is used on OS X
+        echo "Using $(command -v md5) to verify checksums" >&2
+        function md5check() {
+                echo $(md5 ${1} | awk '{ print $4 }')
+        }
+elif command -v openssl >/dev/null 2>&1 ; then # openssl is used if none of the above are found.
+        echo "Using $(command -v openssl) dgst -md5 to verify checksums" >&2
+        function md5check() {
+                echo $(openssl dgst -md5 ${1} | awk '{ print $2 }')
+        }
+else
+        fail "No utility to check MD5 found."
+        exit 1
+fi
 

--- a/lib/common.inc
+++ b/lib/common.inc
@@ -20,22 +20,3 @@ function bold() {
 	local text=${1}
 	echo "$(tput bold)${text}$(tput sgr0)"
 };
-
-# Autodetect MD5 checker, md5sum, md5, openssl dgst -md5
-if command -v md5sum >/dev/null 2>&1 ; then # md5sum is used on Linux
-        function md5check() {
-                echo $(md5sum ${1} | awk '{ print $1 }')
-        }
-elif command -v md5 >/dev/null 2>&1 ; then # md5 is used on OS X
-        function md5check() {
-                echo $(md5 ${1} | awk '{ print $4 }')
-        }
-elif command -v openssl >/dev/null 2>&1 ; then # openssl is used if none of the above are found.
-        function md5check() {
-                echo $(openssl dgst -md5 ${1} | awk '{ print $2 }')
-        }
-else
-        fail "No utility to check MD5 found."
-        exit 1
-fi
-

--- a/lib/init
+++ b/lib/init
@@ -27,7 +27,7 @@ function verify_tarballs() {
 function extract_tarballs() {
         for file in work/*.tar.gz; do
                 echo -ne "\textracting: ${file}"
-		tar xfiz ${file} -C "work/" || fail "could not extract ${file}"
+		tar xzf ${file} -C "work/" || fail "could not extract ${file}"
 		echo -e "\t\t$(bold DONE)"
 	done
 }

--- a/lib/init
+++ b/lib/init
@@ -13,7 +13,7 @@ function verify_tarballs() {
 			echo -e "\t${file}: $(bold "NO MD5 SIGNATURE")"
 			continue
 		fi
-		local sum_local=$(md5sum ${file} | awk '{ print $1 }')
+		local sum_local=$(md5check ${file})
 		local sum_remote=$(cat ${file}.md5 2>/dev/null | sed 's/.*=\ //')
 		echo -ne "\t${file}: "
 		if [[ ${sum_local} == ${sum_remote} ]]; then

--- a/lib/init
+++ b/lib/init
@@ -71,7 +71,7 @@ if command -v wget >/dev/null 2>&1 ; then
 		"https://www.openssl.org/source" &>/dev/null || fail "could not download OpenSSL"	
 elif command -v curl >/dev/null 2>&1 ; then
 	# Yes, this is ugly
-	cd work && curl -s 'https://www.openssl.org/source/' | grep .tar.gz | sed -e 's/^.*href=\"/https\:\/\/www\.openssl\.org\/source\//g' -e 's/\.tar\.gz.*/\.tar\.gz/g' | uniq | while read url; do curl -LO -# -R -C - "{$url}" -LO -# -R -C - "{$url}.md5" ; done ; cd ..
+	cd work && curl -s 'https://www.openssl.org/source/' | grep .tar.gz | sed -e 's/^.*href=\"/https\:\/\/www\.openssl\.org\/source\//g' -e 's/\.tar\.gz.*/\.tar\.gz/g' | uniq | while read url; do curl -LO -# -R -C - "{$url}" -LO -# -R -C - "{$url}.sha256" ; done ; cd ..
 else
 	fail "Could't find wget or curl to fetch sources."
 	exit 1

--- a/lib/init
+++ b/lib/init
@@ -9,12 +9,12 @@ function verify_tarballs() {
 	# OpenSSL fact: improper use of md5sum. you cannot mass verify tarballs
 	# http://nopaste.narf.at/show/DL0GE8RcTKH0BZO3vLux/
 	for file in work/*.tar.gz; do
-		if [ ! -f ${file}.md5 ]; then
-			echo -e "\t${file}: $(bold "NO MD5 SIGNATURE")"
+		if [ ! -f ${file}.sha256 ]; then
+			echo -e "\t${file}: $(bold "NO SHA256 SIGNATURE")"
 			continue
 		fi
-		local sum_local=$(md5check ${file})
-		local sum_remote=$(cat ${file}.md5 2>/dev/null | sed 's/.*=\ //')
+		local sum_local=$(sha256check ${file})
+		local sum_remote=$(cat ${file}.sha256 2>/dev/null | sed 's/.*=\ //')
 		echo -ne "\t${file}: "
 		if [[ ${sum_local} == ${sum_remote} ]]; then
 			echo "$(bold verified)"
@@ -33,20 +33,12 @@ function extract_tarballs() {
 }
 
 # Autodetect MD5 checker, md5sum, md5, openssl dgst -md5
-if command -v md5sum >/dev/null 2>&1 ; then # md5sum is used on Linux
-        function md5check() {
-                echo $(md5sum ${1} | awk '{ print $1 }')
-        }
-elif command -v md5 >/dev/null 2>&1 ; then # md5 is used on OS X
-        function md5check() {
-                echo $(md5 ${1} | awk '{ print $4 }')
-        }
-elif command -v openssl >/dev/null 2>&1 ; then # openssl is used if none of the above are found.
-        function md5check() {
-                echo $(openssl dgst -md5 ${1} | awk '{ print $2 }')
+if command -v openssl >/dev/null 2>&1 ; then
+        function sha256check() {
+                echo $(openssl dgst -sha256 ${1} | awk '{ print $2 }')
         }
 else
-        fail "No utility to check MD5 found."
+        fail "FATAL: No OpenSSL found to check SHA256"
         exit 1
 fi
 
@@ -75,7 +67,7 @@ fi
 echo "${banner} downloading all OpenSSL sources - this might take a while"
 
 if command -v wget >/dev/null 2>&1 ; then
-	wget -r -l2 -nd -Nc -A "*.tar.gz" -A "*.md5" -P "work/" \
+	wget -r -l2 -nd -Nc -A "*.tar.gz" -A "*.sha256" -P "work/" \
 		"https://www.openssl.org/source" &>/dev/null || fail "could not download OpenSSL"	
 elif command -v curl >/dev/null 2>&1 ; then
 	# Yes, this is ugly

--- a/lib/init
+++ b/lib/init
@@ -32,6 +32,25 @@ function extract_tarballs() {
 	done
 }
 
+# Autodetect MD5 checker, md5sum, md5, openssl dgst -md5
+if command -v md5sum >/dev/null 2>&1 ; then # md5sum is used on Linux
+        function md5check() {
+                echo $(md5sum ${1} | awk '{ print $1 }')
+        }
+elif command -v md5 >/dev/null 2>&1 ; then # md5 is used on OS X
+        function md5check() {
+                echo $(md5 ${1} | awk '{ print $4 }')
+        }
+elif command -v openssl >/dev/null 2>&1 ; then # openssl is used if none of the above are found.
+        function md5check() {
+                echo $(openssl dgst -md5 ${1} | awk '{ print $2 }')
+        }
+else
+        fail "No utility to check MD5 found."
+        exit 1
+fi
+
+
 while getopts ":h" opts; do
 	case ${opts} in
 		w)	wipe=true ;;

--- a/lib/init
+++ b/lib/init
@@ -54,8 +54,18 @@ if [ ! -d "work/" ]; then
 fi
 
 echo "${banner} downloading all OpenSSL sources - this might take a while"
-wget -r -l2 -nd -Nc -A "*.tar.gz" -A "*.md5" -P "work/" \
-	"https://www.openssl.org/source" &>/dev/null || fail "could not download OpenSSL"
+
+if command -v wget >/dev/null 2>&1 ; then
+	wget -r -l2 -nd -Nc -A "*.tar.gz" -A "*.md5" -P "work/" \
+		"https://www.openssl.org/source" &>/dev/null || fail "could not download OpenSSL"	
+elif command -v curl >/dev/null 2>&1 ; then
+	# Yes, this is ugly
+	cd work && curl -s 'https://www.openssl.org/source/' | grep .tar.gz | sed -e 's/^.*href=\"/https\:\/\/www\.openssl\.org\/source\//g' -e 's/\.tar\.gz.*/\.tar\.gz/g' | uniq | while read url; do curl -LO -# -R -C - "{$url}" -LO -# -R -C - "{$url}.md5" ; done ; cd ..
+else
+	fail "Could't find wget or curl to fetch sources."
+	exit 1
+fi
+
 
 echo "${banner} verifying tarballs:"
 verify_tarballs


### PR DESCRIPTION
I've changed the `MD5` verifications to `SHA25` since OpenSSL doesn't publish `MD5` sums anymore. Which means, openssl-compare actually can be used again.

Verification of `SHA256` is always done with `openssl` now.
Timestamps are now ISO8601 to be less ambiguous working with GNU and BSD `date`.
Downloads now work when either of `wget` or `curl` is available.
